### PR TITLE
Default option filter  should be "*" instead of "\\*"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ const buildRequestXml = function(id, options) {
   }
 
   if (!options.filter) {
-    options.filter = '\\*';
+    options.filter = '*';
   }
 
   if (!options.startIndex) {


### PR DESCRIPTION
Default option for 'filter' should be `"*"` instead of `"\\*"` - see
specification below.
`"\\*"` strips the item resource data in the response - using miniDLNA
server

Spec:
http://www.upnp.org/specs/av/UPnP-av-ContentDirectory-v1-Service-2002062
5.pdf